### PR TITLE
Remove sub path from volume mount

### DIFF
--- a/pkg/apis/appdynamics/v1alpha1/clusteragent_types.go
+++ b/pkg/apis/appdynamics/v1alpha1/clusteragent_types.go
@@ -26,24 +26,26 @@ type ClusteragentSpec struct {
 	ProxyPass       string                      `json:"proxyPass,omitempty"`
 
 	//limits
-	EventAPILimit                 int    `json:"eventAPILimit,omitempty"`
-	MetricsSyncInterval           int    `json:"metricsSyncInterval,omitempty"`
-	ClusterMetricsSyncInterval    int    `json:"clusterMetricsSyncInterval,omitempty"`
-	MetadataSyncInterval          int    `json:"metadataSyncInterval,omitempty"`
-	SnapshotSyncInterval          int    `json:"snapshotSyncInterval,omitempty"`
-	EventUploadInterval           int    `json:"eventUploadInterval,omitempty"`
-	ContainerRegistrationInterval int    `json:"containerRegistrationInterval,omitempty"`
-	HttpClientTimeout             int    `json:"httpClientTimeout,omitempty"`
-	ContainerBatchSize            int    `json:"containerBatchSize,omitempty"`
-	ContainerParallelRequestLimit int    `json:"containerParallelRequestLimit,omitempty"`
-	PodBatchSize                  int    `json:"podBatchSize,omitempty"`
-	LogLines                      int    `json:"logLines,omitempty"`
-	LogLevel                      string `json:"logLevel,omitempty"`
-	LogFileSizeMb                 int    `json:"logFileSizeMb,omitempty"`
-	LogFileBackups                int    `json:"logFileBackups,omitempty"`
-	StdoutLogging                 string `json:"stdoutLogging,omitempty"`
-	PodEventNumber                int    `json:"podEventNumber,omitempty"`
-	OverconsumptionThreshold      int    `json:"overconsumptionThreshold,omitempty"`
+	EventAPILimit                         int    `json:"eventAPILimit,omitempty"`
+	MetricsSyncInterval                   int    `json:"metricsSyncInterval,omitempty"`
+	ClusterMetricsSyncInterval            int    `json:"clusterMetricsSyncInterval,omitempty"`
+	MetadataSyncInterval                  int    `json:"metadataSyncInterval,omitempty"`
+	SnapshotSyncInterval                  int    `json:"snapshotSyncInterval,omitempty"`
+	EventUploadInterval                   int    `json:"eventUploadInterval,omitempty"`
+	ContainerRegistrationInterval         int    `json:"containerRegistrationInterval,omitempty"`
+	HttpClientTimeout                     int    `json:"httpClientTimeout,omitempty"`
+	ContainerBatchSize                    int    `json:"containerBatchSize,omitempty"`
+	ContainerParallelRequestLimit         int    `json:"containerParallelRequestLimit,omitempty"`
+	PodBatchSize                          int    `json:"podBatchSize,omitempty"`
+	LogLines                              int    `json:"logLines,omitempty"`
+	LogLevel                              string `json:"logLevel,omitempty"`
+	LogFileSizeMb                         int    `json:"logFileSizeMb,omitempty"`
+	LogFileBackups                        int    `json:"logFileBackups,omitempty"`
+	StdoutLogging                         string `json:"stdoutLogging,omitempty"`
+	PodEventNumber                        int    `json:"podEventNumber,omitempty"`
+	OverconsumptionThreshold              int    `json:"overconsumptionThreshold,omitempty"`
+	MetricUploadRetryCount                int    `json:"metricUploadRetryCount,omitempty"`
+	MetricUploadRetryIntervalMilliSeconds int    `json:"metricUploadRetryIntervalMilliSeconds,omitempty"`
 
 	//instrumentation
 	InstrumentationMethod       string                      `json:"instrumentationMethod,omitempty"`

--- a/pkg/controller/clusteragent/clusteragent_controller.go
+++ b/pkg/controller/clusteragent/clusteragent_controller.go
@@ -568,6 +568,10 @@ func (r *ReconcileClusteragent) newAgentDeployment(clusterAgent *appdynamicsv1al
 							{
 								Name:      "agent-log",
 								MountPath: "/opt/appdynamics/cluster-agent/config/logging/",
+							},
+							{
+								Name:      "appdynamics-logs",
+								MountPath: "/opt/appdynamics/cluster-agent/logs",
 							}},
 					}},
 					Volumes: []corev1.Volume{{
@@ -587,6 +591,15 @@ func (r *ReconcileClusteragent) newAgentDeployment(clusterAgent *appdynamicsv1al
 									LocalObjectReference: corev1.LocalObjectReference{
 										Name: AGENT_LOG_CONFIG_NAME,
 									},
+								},
+							},
+						},
+						{
+							Name: "appdynamics-logs",
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{
+									Medium:    "",
+									SizeLimit: nil,
 								},
 							},
 						}},
@@ -761,6 +774,5 @@ func createContainerFilterString(clusterAgent *appdynamicsv1alpha1.Clusteragent)
 	if clusterAgent.Spec.ContainerFilter.WhitelistedNames != nil {
 		containerFilterString.WriteString(parseFilterField("whitelisted-names", clusterAgent.Spec.ContainerFilter.WhitelistedNames))
 	}
-
 	return containerFilterString.String()
 }

--- a/pkg/controller/clusteragent/clusteragent_controller.go
+++ b/pkg/controller/clusteragent/clusteragent_controller.go
@@ -560,8 +560,7 @@ func (r *ReconcileClusteragent) newAgentDeployment(clusterAgent *appdynamicsv1al
 						Resources:       clusterAgent.Spec.Resources,
 						VolumeMounts: []corev1.VolumeMount{{
 							Name:      "agent-mon-config",
-							MountPath: "/opt/appdynamics/cluster-agent/config/agent-monitoring.yml",
-							SubPath:   "agent-monitoring.yml",
+							MountPath: "/opt/appdynamics/cluster-agent/config/agent-monitoring/",
 						},
 							{
 								Name:      "agent-log",

--- a/pkg/controller/clusteragent/clusteragent_controller.go
+++ b/pkg/controller/clusteragent/clusteragent_controller.go
@@ -568,10 +568,6 @@ func (r *ReconcileClusteragent) newAgentDeployment(clusterAgent *appdynamicsv1al
 							{
 								Name:      "agent-log",
 								MountPath: "/opt/appdynamics/cluster-agent/config/logging/",
-							},
-							{
-								Name:      "appdynamics-logs",
-								MountPath: "/opt/appdynamics/cluster-agent/logs",
 							}},
 					}},
 					Volumes: []corev1.Volume{{
@@ -591,15 +587,6 @@ func (r *ReconcileClusteragent) newAgentDeployment(clusterAgent *appdynamicsv1al
 									LocalObjectReference: corev1.LocalObjectReference{
 										Name: AGENT_LOG_CONFIG_NAME,
 									},
-								},
-							},
-						},
-						{
-							Name: "appdynamics-logs",
-							VolumeSource: corev1.VolumeSource{
-								EmptyDir: &corev1.EmptyDirVolumeSource{
-									Medium:    "",
-									SizeLimit: nil,
 								},
 							},
 						}},
@@ -774,5 +761,6 @@ func createContainerFilterString(clusterAgent *appdynamicsv1alpha1.Clusteragent)
 	if clusterAgent.Spec.ContainerFilter.WhitelistedNames != nil {
 		containerFilterString.WriteString(parseFilterField("whitelisted-names", clusterAgent.Spec.ContainerFilter.WhitelistedNames))
 	}
+
 	return containerFilterString.String()
 }


### PR DESCRIPTION
If we specify subPath in a volumeMount which is using a configMap, it does not receive configMap updates.